### PR TITLE
Initialize Java hexagonal architecture skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
 # ordenes-producci-n
-Desarrollar un sistema backend que permita registrar y gestionar de prodordenes uccion en una fabrica.
+
+Base de proyecto en Java 8 siguiendo la arquitectura Hexagonal para gestionar 
+ordenes de producción. La lógica de negocio aún no ha sido implementada.
+
+## Estructura
+
+- **domain**: contiene las entidades y repositorios del dominio.
+- **application**: define los casos de uso y servicios de aplicación.
+- **infrastructure**: implementación de repositorios y punto de entrada.
+
+## Compilación
+
+Utilice Gradle para compilar el proyecto:
+
+```bash
+gradle build
+```
+
+Esto genera los artefactos de cada módulo. El módulo `infrastructure` contiene
+una clase `MainApplication` con un ejemplo básico de ejecución.

--- a/application/build.gradle
+++ b/application/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+    api project(':domain')
+}

--- a/application/src/main/java/com/example/ordenes/application/usecase/ManageProductionOrderService.java
+++ b/application/src/main/java/com/example/ordenes/application/usecase/ManageProductionOrderService.java
@@ -1,0 +1,35 @@
+package com.example.ordenes.application.usecase;
+
+import com.example.ordenes.domain.model.ProductionOrder;
+import com.example.ordenes.domain.repository.ProductionOrderRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Implementación del caso de uso que delega en el repositorio.
+ */
+public class ManageProductionOrderService implements ManageProductionOrderUseCase {
+
+    private final ProductionOrderRepository repository;
+
+    public ManageProductionOrderService(ProductionOrderRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public ProductionOrder create(ProductionOrder order) {
+        // Lógica de negocio pendiente
+        return repository.save(order);
+    }
+
+    @Override
+    public Optional<ProductionOrder> get(Long id) {
+        return repository.findById(id);
+    }
+
+    @Override
+    public List<ProductionOrder> list() {
+        return repository.findAll();
+    }
+}

--- a/application/src/main/java/com/example/ordenes/application/usecase/ManageProductionOrderUseCase.java
+++ b/application/src/main/java/com/example/ordenes/application/usecase/ManageProductionOrderUseCase.java
@@ -1,0 +1,18 @@
+package com.example.ordenes.application.usecase;
+
+import com.example.ordenes.domain.model.ProductionOrder;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Caso de uso para gestionar las ordenes de producción.
+ */
+public interface ManageProductionOrderUseCase {
+
+    ProductionOrder create(ProductionOrder order);
+
+    Optional<ProductionOrder> get(Long id);
+
+    List<ProductionOrder> list();
+}

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,17 @@
+plugins {
+    id 'java-library'
+}
+
+subprojects {
+    apply plugin: 'java-library'
+
+    group = 'com.example'
+    version = '1.0-SNAPSHOT'
+
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+
+    repositories {
+        mavenCentral()
+    }
+}

--- a/domain/build.gradle
+++ b/domain/build.gradle
@@ -1,0 +1,1 @@
+// Domain module has no external dependencies

--- a/domain/src/main/java/com/example/ordenes/domain/model/ProductionOrder.java
+++ b/domain/src/main/java/com/example/ordenes/domain/model/ProductionOrder.java
@@ -1,0 +1,39 @@
+package com.example.ordenes.domain.model;
+
+import java.time.LocalDateTime;
+
+/**
+ * Entidad que representa una orden de producción.
+ */
+public class ProductionOrder {
+
+    private Long id;
+    private String description;
+    private LocalDateTime createdAt;
+
+    // getters & setters
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/domain/src/main/java/com/example/ordenes/domain/repository/ProductionOrderRepository.java
+++ b/domain/src/main/java/com/example/ordenes/domain/repository/ProductionOrderRepository.java
@@ -1,0 +1,18 @@
+package com.example.ordenes.domain.repository;
+
+import com.example.ordenes.domain.model.ProductionOrder;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Repositorio para gestionar las ordenes de producción.
+ */
+public interface ProductionOrderRepository {
+
+    ProductionOrder save(ProductionOrder order);
+
+    Optional<ProductionOrder> findById(Long id);
+
+    List<ProductionOrder> findAll();
+}

--- a/infrastructure/build.gradle
+++ b/infrastructure/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+    implementation project(':application')
+}

--- a/infrastructure/src/main/java/com/example/ordenes/infrastructure/Bootstrap.java
+++ b/infrastructure/src/main/java/com/example/ordenes/infrastructure/Bootstrap.java
@@ -1,0 +1,15 @@
+package com.example.ordenes.infrastructure;
+
+import com.example.ordenes.application.usecase.ManageProductionOrderService;
+import com.example.ordenes.application.usecase.ManageProductionOrderUseCase;
+import com.example.ordenes.infrastructure.repository.InMemoryProductionOrderRepository;
+
+/**
+ * Configuración manual de dependencias para fines de demostración.
+ */
+public class Bootstrap {
+
+    public ManageProductionOrderUseCase manageProductionOrderUseCase() {
+        return new ManageProductionOrderService(new InMemoryProductionOrderRepository());
+    }
+}

--- a/infrastructure/src/main/java/com/example/ordenes/infrastructure/MainApplication.java
+++ b/infrastructure/src/main/java/com/example/ordenes/infrastructure/MainApplication.java
@@ -1,0 +1,21 @@
+package com.example.ordenes.infrastructure;
+
+import com.example.ordenes.domain.model.ProductionOrder;
+import com.example.ordenes.application.usecase.ManageProductionOrderUseCase;
+
+/**
+ * Punto de entrada de la aplicación.
+ */
+public class MainApplication {
+
+    public static void main(String[] args) {
+        Bootstrap bootstrap = new Bootstrap();
+        ManageProductionOrderUseCase useCase = bootstrap.manageProductionOrderUseCase();
+
+        ProductionOrder order = new ProductionOrder();
+        order.setDescription("Orden inicial");
+        useCase.create(order);
+
+        System.out.println("Ordenes registradas: " + useCase.list().size());
+    }
+}

--- a/infrastructure/src/main/java/com/example/ordenes/infrastructure/repository/InMemoryProductionOrderRepository.java
+++ b/infrastructure/src/main/java/com/example/ordenes/infrastructure/repository/InMemoryProductionOrderRepository.java
@@ -1,0 +1,34 @@
+package com.example.ordenes.infrastructure.repository;
+
+import com.example.ordenes.domain.model.ProductionOrder;
+import com.example.ordenes.domain.repository.ProductionOrderRepository;
+
+import java.util.*;
+
+/**
+ * Implementación en memoria del repositorio.
+ */
+public class InMemoryProductionOrderRepository implements ProductionOrderRepository {
+
+    private final Map<Long, ProductionOrder> storage = new HashMap<>();
+    private long sequence = 0L;
+
+    @Override
+    public ProductionOrder save(ProductionOrder order) {
+        if (order.getId() == null) {
+            order.setId(++sequence);
+        }
+        storage.put(order.getId(), order);
+        return order;
+    }
+
+    @Override
+    public Optional<ProductionOrder> findById(Long id) {
+        return Optional.ofNullable(storage.get(id));
+    }
+
+    @Override
+    public List<ProductionOrder> findAll() {
+        return new ArrayList<>(storage.values());
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,2 @@
+rootProject.name = 'ordenes-produccion'
+include 'domain', 'application', 'infrastructure'


### PR DESCRIPTION
## Summary
- set up Maven multi-module project with hexagonal architecture
- add domain layer with ProductionOrder entity and repository interface
- add application layer with use case interfaces and simple service
- add infrastructure layer with in-memory repository and manual Bootstrap
- update README with build instructions
- **switch build system to Gradle**

## Testing
- `gradle build`


------
https://chatgpt.com/codex/tasks/task_e_684f3a0f6b10832a8698ca0513a57448