### PR TITLE
Initialize Java hexagonal architecture skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
 # ordenes-producci-n
-Desarrollar un sistema backend que permita registrar y gestionar de prodordenes uccion en una fabrica.
+
+Base de proyecto en Java 8 siguiendo la arquitectura Hexagonal para gestionar 
+ordenes de producción. La lógica de negocio aún no ha sido implementada.
+
+## Estructura
+
+- **domain**: contiene las entidades y repositorios del dominio.
+- **application**: define los casos de uso y servicios de aplicación.
+- **infrastructure**: implementación de repositorios y punto de entrada.
+
+## Compilación
+
+Utilice Gradle para compilar el proyecto:
+
+```bash
+gradle build
+```
+
+Esto genera los artefactos de cada módulo. El módulo `infrastructure` contiene
+una clase `MainApplication` con un ejemplo básico de ejecución.
+
+El registro de trabajadores se obtiene de la API pública de ReqRes.
+Cada petición envía la cabecera `x-api-key: reqres-free-v1` y está
+protegida por un Circuit Breaker básico en el módulo `infrastructure`.

--- a/application/build.gradle
+++ b/application/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+    api project(':domain')
+}

--- a/application/src/main/java/com/example/ordenes/application/usecase/ManageProductionOrderService.java
+++ b/application/src/main/java/com/example/ordenes/application/usecase/ManageProductionOrderService.java
@@ -1,0 +1,35 @@
+package com.example.ordenes.application.usecase;
+
+import com.example.ordenes.domain.model.ProductionOrder;
+import com.example.ordenes.domain.repository.ProductionOrderRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Implementación del caso de uso que delega en el repositorio.
+ */
+public class ManageProductionOrderService implements ManageProductionOrderUseCase {
+
+    private final ProductionOrderRepository repository;
+
+    public ManageProductionOrderService(ProductionOrderRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public ProductionOrder create(ProductionOrder order) {
+        // Lógica de negocio pendiente
+        return repository.save(order);
+    }
+
+    @Override
+    public Optional<ProductionOrder> get(Long id) {
+        return repository.findById(id);
+    }
+
+    @Override
+    public List<ProductionOrder> list() {
+        return repository.findAll();
+    }
+}

--- a/application/src/main/java/com/example/ordenes/application/usecase/ManageProductionOrderUseCase.java
+++ b/application/src/main/java/com/example/ordenes/application/usecase/ManageProductionOrderUseCase.java
@@ -1,0 +1,18 @@
+package com.example.ordenes.application.usecase;
+
+import com.example.ordenes.domain.model.ProductionOrder;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Caso de uso para gestionar las ordenes de producción.
+ */
+public interface ManageProductionOrderUseCase {
+
+    ProductionOrder create(ProductionOrder order);
+
+    Optional<ProductionOrder> get(Long id);
+
+    List<ProductionOrder> list();
+}

--- a/application/src/main/java/com/example/ordenes/application/usecase/ManageWorkerService.java
+++ b/application/src/main/java/com/example/ordenes/application/usecase/ManageWorkerService.java
@@ -1,0 +1,23 @@
+package com.example.ordenes.application.usecase;
+
+import com.example.ordenes.domain.model.Worker;
+import com.example.ordenes.domain.repository.WorkerRepository;
+
+import java.util.Optional;
+
+/**
+ * Implementación del caso de uso de trabajadores que delega en el repositorio.
+ */
+public class ManageWorkerService implements ManageWorkerUseCase {
+
+    private final WorkerRepository repository;
+
+    public ManageWorkerService(WorkerRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public Optional<Worker> get(Long id) {
+        return repository.findById(id);
+    }
+}

--- a/application/src/main/java/com/example/ordenes/application/usecase/ManageWorkerUseCase.java
+++ b/application/src/main/java/com/example/ordenes/application/usecase/ManageWorkerUseCase.java
@@ -1,0 +1,13 @@
+package com.example.ordenes.application.usecase;
+
+import com.example.ordenes.domain.model.Worker;
+
+import java.util.Optional;
+
+/**
+ * Caso de uso para obtener información de trabajadores.
+ */
+public interface ManageWorkerUseCase {
+
+    Optional<Worker> get(Long id);
+}

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,17 @@
+plugins {
+    id 'java-library'
+}
+
+subprojects {
+    apply plugin: 'java-library'
+
+    group = 'com.example'
+    version = '1.0-SNAPSHOT'
+
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+
+    repositories {
+        mavenCentral()
+    }
+}

--- a/domain/build.gradle
+++ b/domain/build.gradle
@@ -1,0 +1,1 @@
+// Domain module has no external dependencies

--- a/domain/src/main/java/com/example/ordenes/domain/model/ProductionOrder.java
+++ b/domain/src/main/java/com/example/ordenes/domain/model/ProductionOrder.java
@@ -1,0 +1,39 @@
+package com.example.ordenes.domain.model;
+
+import java.time.LocalDateTime;
+
+/**
+ * Entidad que representa una orden de producción.
+ */
+public class ProductionOrder {
+
+    private Long id;
+    private String description;
+    private LocalDateTime createdAt;
+
+    // getters & setters
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/domain/src/main/java/com/example/ordenes/domain/model/Worker.java
+++ b/domain/src/main/java/com/example/ordenes/domain/model/Worker.java
@@ -1,0 +1,44 @@
+package com.example.ordenes.domain.model;
+
+/**
+ * Entidad que representa un trabajador.
+ */
+public class Worker {
+
+    private Long id;
+    private String email;
+    private String firstName;
+    private String lastName;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+}

--- a/domain/src/main/java/com/example/ordenes/domain/repository/ProductionOrderRepository.java
+++ b/domain/src/main/java/com/example/ordenes/domain/repository/ProductionOrderRepository.java
@@ -1,0 +1,18 @@
+package com.example.ordenes.domain.repository;
+
+import com.example.ordenes.domain.model.ProductionOrder;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Repositorio para gestionar las ordenes de producción.
+ */
+public interface ProductionOrderRepository {
+
+    ProductionOrder save(ProductionOrder order);
+
+    Optional<ProductionOrder> findById(Long id);
+
+    List<ProductionOrder> findAll();
+}

--- a/domain/src/main/java/com/example/ordenes/domain/repository/WorkerRepository.java
+++ b/domain/src/main/java/com/example/ordenes/domain/repository/WorkerRepository.java
@@ -1,0 +1,13 @@
+package com.example.ordenes.domain.repository;
+
+import com.example.ordenes.domain.model.Worker;
+
+import java.util.Optional;
+
+/**
+ * Repositorio para gestionar la información de trabajadores.
+ */
+public interface WorkerRepository {
+
+    Optional<Worker> findById(Long id);
+}

--- a/infrastructure/build.gradle
+++ b/infrastructure/build.gradle
@@ -1,0 +1,4 @@
+dependencies {
+    implementation project(':application')
+    implementation 'org.json:json:20220320'
+}

--- a/infrastructure/src/main/java/com/example/ordenes/infrastructure/Bootstrap.java
+++ b/infrastructure/src/main/java/com/example/ordenes/infrastructure/Bootstrap.java
@@ -1,0 +1,19 @@
+package com.example.ordenes.infrastructure;
+
+import com.example.ordenes.application.usecase.*;
+import com.example.ordenes.infrastructure.repository.InMemoryProductionOrderRepository;
+import com.example.ordenes.infrastructure.api.WorkerApiRepository;
+
+/**
+ * Configuración manual de dependencias para fines de demostración.
+ */
+public class Bootstrap {
+
+    public ManageProductionOrderUseCase manageProductionOrderUseCase() {
+        return new ManageProductionOrderService(new InMemoryProductionOrderRepository());
+    }
+
+    public ManageWorkerUseCase manageWorkerUseCase() {
+        return new ManageWorkerService(new WorkerApiRepository());
+    }
+}

--- a/infrastructure/src/main/java/com/example/ordenes/infrastructure/MainApplication.java
+++ b/infrastructure/src/main/java/com/example/ordenes/infrastructure/MainApplication.java
@@ -1,0 +1,26 @@
+package com.example.ordenes.infrastructure;
+
+import com.example.ordenes.domain.model.ProductionOrder;
+import com.example.ordenes.application.usecase.ManageProductionOrderUseCase;
+import com.example.ordenes.application.usecase.ManageWorkerUseCase;
+
+/**
+ * Punto de entrada de la aplicación.
+ */
+public class MainApplication {
+
+    public static void main(String[] args) {
+        Bootstrap bootstrap = new Bootstrap();
+        ManageProductionOrderUseCase useCase = bootstrap.manageProductionOrderUseCase();
+        ManageWorkerUseCase workerUseCase = bootstrap.manageWorkerUseCase();
+
+        ProductionOrder order = new ProductionOrder();
+        order.setDescription("Orden inicial");
+        useCase.create(order);
+
+        System.out.println("Ordenes registradas: " + useCase.list().size());
+
+        workerUseCase.get(1L).ifPresent(worker ->
+                System.out.println("Trabajador obtenido: " + worker.getFirstName() + " " + worker.getLastName()));
+    }
+}

--- a/infrastructure/src/main/java/com/example/ordenes/infrastructure/api/WorkerApiRepository.java
+++ b/infrastructure/src/main/java/com/example/ordenes/infrastructure/api/WorkerApiRepository.java
@@ -1,0 +1,67 @@
+package com.example.ordenes.infrastructure.api;
+
+import com.example.ordenes.domain.model.Worker;
+import com.example.ordenes.domain.repository.WorkerRepository;
+import com.example.ordenes.infrastructure.circuit.CircuitBreaker;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.json.JSONObject;
+
+/**
+ * Repositorio que obtiene trabajadores de la API externa.
+ */
+public class WorkerApiRepository implements WorkerRepository {
+
+    private static final String API_URL = "https://reqres.in/api/users/";
+    private static final String API_KEY = "reqres-free-v1";
+
+    private final CircuitBreaker circuitBreaker;
+
+    public WorkerApiRepository() {
+        // 3 fallos permiten abrir el circuito, reintento tras 5 segundos
+        this.circuitBreaker = new CircuitBreaker(3, 5000);
+    }
+
+    @Override
+    public Optional<Worker> findById(Long id) {
+        try {
+            return circuitBreaker.execute(() -> Optional.ofNullable(callApi(id)));
+        } catch (RuntimeException e) {
+            return Optional.empty();
+        }
+    }
+
+    private Worker callApi(Long id) {
+        try {
+            URL url = new URL(API_URL + id);
+            HttpURLConnection con = (HttpURLConnection) url.openConnection();
+            con.setRequestMethod("GET");
+            con.setRequestProperty("x-api-key", API_KEY);
+
+            int status = con.getResponseCode();
+            if (status >= 200 && status < 300) {
+                try (BufferedReader in = new BufferedReader(new InputStreamReader(con.getInputStream()))) {
+                    String body = in.lines().collect(Collectors.joining());
+                    JSONObject json = new JSONObject(body).getJSONObject("data");
+                    Worker worker = new Worker();
+                    worker.setId(json.getLong("id"));
+                    worker.setEmail(json.getString("email"));
+                    worker.setFirstName(json.getString("first_name"));
+                    worker.setLastName(json.getString("last_name"));
+                    return worker;
+                }
+            } else {
+                throw new IOException("Unexpected status: " + status);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Error calling worker API", e);
+        }
+    }
+}

--- a/infrastructure/src/main/java/com/example/ordenes/infrastructure/circuit/CircuitBreaker.java
+++ b/infrastructure/src/main/java/com/example/ordenes/infrastructure/circuit/CircuitBreaker.java
@@ -1,0 +1,55 @@
+package com.example.ordenes.infrastructure.circuit;
+
+import java.util.function.Supplier;
+
+/**
+ * Implementación simple de Circuit Breaker.
+ */
+public class CircuitBreaker {
+
+    private enum State { CLOSED, OPEN, HALF_OPEN }
+
+    private final int failureThreshold;
+    private final long retryTimePeriodMillis;
+
+    private int failureCount = 0;
+    private long lastFailureTime = 0L;
+    private State state = State.CLOSED;
+
+    public CircuitBreaker(int failureThreshold, long retryTimePeriodMillis) {
+        this.failureThreshold = failureThreshold;
+        this.retryTimePeriodMillis = retryTimePeriodMillis;
+    }
+
+    public synchronized <T> T execute(Supplier<T> supplier) {
+        if (state == State.OPEN) {
+            if (System.currentTimeMillis() - lastFailureTime > retryTimePeriodMillis) {
+                state = State.HALF_OPEN;
+            } else {
+                throw new IllegalStateException("Circuit is open");
+            }
+        }
+
+        try {
+            T result = supplier.get();
+            reset();
+            return result;
+        } catch (RuntimeException e) {
+            recordFailure();
+            throw e;
+        }
+    }
+
+    private void recordFailure() {
+        failureCount++;
+        lastFailureTime = System.currentTimeMillis();
+        if (failureCount >= failureThreshold) {
+            state = State.OPEN;
+        }
+    }
+
+    private void reset() {
+        failureCount = 0;
+        state = State.CLOSED;
+    }
+}

--- a/infrastructure/src/main/java/com/example/ordenes/infrastructure/repository/InMemoryProductionOrderRepository.java
+++ b/infrastructure/src/main/java/com/example/ordenes/infrastructure/repository/InMemoryProductionOrderRepository.java
@@ -1,0 +1,34 @@
+package com.example.ordenes.infrastructure.repository;
+
+import com.example.ordenes.domain.model.ProductionOrder;
+import com.example.ordenes.domain.repository.ProductionOrderRepository;
+
+import java.util.*;
+
+/**
+ * Implementación en memoria del repositorio.
+ */
+public class InMemoryProductionOrderRepository implements ProductionOrderRepository {
+
+    private final Map<Long, ProductionOrder> storage = new HashMap<>();
+    private long sequence = 0L;
+
+    @Override
+    public ProductionOrder save(ProductionOrder order) {
+        if (order.getId() == null) {
+            order.setId(++sequence);
+        }
+        storage.put(order.getId(), order);
+        return order;
+    }
+
+    @Override
+    public Optional<ProductionOrder> findById(Long id) {
+        return Optional.ofNullable(storage.get(id));
+    }
+
+    @Override
+    public List<ProductionOrder> findAll() {
+        return new ArrayList<>(storage.values());
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,2 @@
+rootProject.name = 'ordenes-produccion'
+include 'domain', 'application', 'infrastructure'


### PR DESCRIPTION
## Summary
- set up Maven multi-module project with hexagonal architecture
- add domain layer with ProductionOrder entity and repository interface
- add application layer with use case interfaces and simple service
- add infrastructure layer with in-memory repository and manual Bootstrap
- update README with build instructions
- **switch build system to Gradle**
- add worker management through external API using Circuit Breaker

## Testing
- `gradle build`


------
https://chatgpt.com/codex/tasks/task_e_684f3a0f6b10832a8698ca0513a57448