### PR TITLE
Add worker HTTP endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,17 @@ gradle build
 ```
 
 Esto genera los artefactos de cada módulo. El módulo `infrastructure` contiene
-una clase `MainApplication` con un ejemplo básico de ejecución.
+una clase `MainApplication` que inicia un pequeño servidor HTTP para consultar
+trabajadores.
+
+Para arrancarlo ejecute:
+
+```bash
+gradle :infrastructure:run
+```
+
+Luego podrá acceder con Postman a `http://localhost:8080/workers/{id}` para
+obtener la información de un trabajador.
 
 El registro de trabajadores se obtiene de la API pública de ReqRes.
 Cada petición envía la cabecera `x-api-key: reqres-free-v1` y está

--- a/infrastructure/src/main/java/com/example/ordenes/infrastructure/MainApplication.java
+++ b/infrastructure/src/main/java/com/example/ordenes/infrastructure/MainApplication.java
@@ -1,26 +1,19 @@
 package com.example.ordenes.infrastructure;
 
-import com.example.ordenes.domain.model.ProductionOrder;
-import com.example.ordenes.application.usecase.ManageProductionOrderUseCase;
 import com.example.ordenes.application.usecase.ManageWorkerUseCase;
+import com.example.ordenes.infrastructure.server.WorkerHttpServer;
 
 /**
  * Punto de entrada de la aplicación.
  */
 public class MainApplication {
 
-    public static void main(String[] args) {
+    public static void main(String[] args) throws Exception {
         Bootstrap bootstrap = new Bootstrap();
-        ManageProductionOrderUseCase useCase = bootstrap.manageProductionOrderUseCase();
         ManageWorkerUseCase workerUseCase = bootstrap.manageWorkerUseCase();
 
-        ProductionOrder order = new ProductionOrder();
-        order.setDescription("Orden inicial");
-        useCase.create(order);
-
-        System.out.println("Ordenes registradas: " + useCase.list().size());
-
-        workerUseCase.get(1L).ifPresent(worker ->
-                System.out.println("Trabajador obtenido: " + worker.getFirstName() + " " + worker.getLastName()));
+        WorkerHttpServer server = new WorkerHttpServer(workerUseCase);
+        server.start(8080);
+        System.out.println("Servidor iniciado en http://localhost:8080");
     }
 }

--- a/infrastructure/src/main/java/com/example/ordenes/infrastructure/server/WorkerHttpServer.java
+++ b/infrastructure/src/main/java/com/example/ordenes/infrastructure/server/WorkerHttpServer.java
@@ -1,0 +1,72 @@
+package com.example.ordenes.infrastructure.server;
+
+import com.example.ordenes.application.usecase.ManageWorkerUseCase;
+import com.example.ordenes.domain.model.Worker;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.util.Optional;
+
+/**
+ * Servidor HTTP sencillo para exponer el endpoint de trabajadores.
+ */
+public class WorkerHttpServer {
+
+    private final ManageWorkerUseCase manageWorkerUseCase;
+    private HttpServer server;
+
+    public WorkerHttpServer(ManageWorkerUseCase manageWorkerUseCase) {
+        this.manageWorkerUseCase = manageWorkerUseCase;
+    }
+
+    /**
+     * Inicia el servidor en el puerto indicado.
+     */
+    public void start(int port) throws IOException {
+        server = HttpServer.create(new InetSocketAddress(port), 0);
+        server.createContext("/workers", this::handleGetWorker);
+        server.setExecutor(null);
+        server.start();
+    }
+
+    private void handleGetWorker(HttpExchange exchange) throws IOException {
+        if (!"GET".equals(exchange.getRequestMethod())) {
+            exchange.sendResponseHeaders(405, -1);
+            return;
+        }
+        String path = exchange.getRequestURI().getPath();
+        String[] parts = path.split("/");
+        if (parts.length != 3) {
+            exchange.sendResponseHeaders(400, -1);
+            return;
+        }
+        try {
+            long id = Long.parseLong(parts[2]);
+            Optional<Worker> workerOpt = manageWorkerUseCase.get(id);
+            if (workerOpt.isPresent()) {
+                Worker worker = workerOpt.get();
+                JSONObject json = new JSONObject()
+                        .put("id", worker.getId())
+                        .put("email", worker.getEmail())
+                        .put("firstName", worker.getFirstName())
+                        .put("lastName", worker.getLastName());
+                byte[] response = json.toString().getBytes();
+                exchange.getResponseHeaders().set("Content-Type", "application/json");
+                exchange.sendResponseHeaders(200, response.length);
+                try (OutputStream os = exchange.getResponseBody()) {
+                    os.write(response);
+                }
+            } else {
+                exchange.sendResponseHeaders(404, -1);
+            }
+        } catch (NumberFormatException e) {
+            exchange.sendResponseHeaders(400, -1);
+        } finally {
+            exchange.close();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- expose workers via `/workers/{id}` using a small HTTP server
- start server in `MainApplication`
- document how to run and test with Postman

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_684f57ff7854832a8ba756361473361d