### PR TITLE
Implement worker creation endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ gradle :infrastructure:run
 ```
 
 Luego podrá acceder con Postman a `http://localhost:8080/workers/{id}` para
-obtener la información de un trabajador.
+obtener la información de un trabajador o realizar un `POST` a
+`http://localhost:8080/workers` para dar de alta uno nuevo.
 
 El registro de trabajadores se obtiene de la API pública de ReqRes.
 Cada petición envía la cabecera `x-api-key: reqres-free-v1` y está

--- a/application/src/main/java/com/example/ordenes/application/usecase/ManageWorkerService.java
+++ b/application/src/main/java/com/example/ordenes/application/usecase/ManageWorkerService.java
@@ -20,4 +20,9 @@ public class ManageWorkerService implements ManageWorkerUseCase {
     public Optional<Worker> get(Long id) {
         return repository.findById(id);
     }
+
+    @Override
+    public Optional<Long> create(String name, String job) {
+        return repository.create(name, job);
+    }
 }

--- a/application/src/main/java/com/example/ordenes/application/usecase/ManageWorkerUseCase.java
+++ b/application/src/main/java/com/example/ordenes/application/usecase/ManageWorkerUseCase.java
@@ -10,4 +10,6 @@ import java.util.Optional;
 public interface ManageWorkerUseCase {
 
     Optional<Worker> get(Long id);
+
+    Optional<Long> create(String name, String job);
 }

--- a/domain/src/main/java/com/example/ordenes/domain/repository/WorkerRepository.java
+++ b/domain/src/main/java/com/example/ordenes/domain/repository/WorkerRepository.java
@@ -10,4 +10,9 @@ import java.util.Optional;
 public interface WorkerRepository {
 
     Optional<Worker> findById(Long id);
+
+    /**
+     * Crea un nuevo trabajador.
+     */
+    Optional<Long> create(String name, String job);
 }

--- a/infrastructure/src/main/java/com/example/ordenes/infrastructure/api/WorkerApiRepository.java
+++ b/infrastructure/src/main/java/com/example/ordenes/infrastructure/api/WorkerApiRepository.java
@@ -7,6 +7,7 @@ import com.example.ordenes.infrastructure.circuit.CircuitBreaker;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.Optional;
@@ -38,6 +39,15 @@ public class WorkerApiRepository implements WorkerRepository {
         }
     }
 
+    @Override
+    public Optional<Long> create(String name, String job) {
+        try {
+            return circuitBreaker.execute(() -> Optional.ofNullable(callCreateApi(name, job)));
+        } catch (RuntimeException e) {
+            return Optional.empty();
+        }
+    }
+
     private Worker callApi(Long id) {
         try {
             URL url = new URL(API_URL + id);
@@ -56,6 +66,38 @@ public class WorkerApiRepository implements WorkerRepository {
                     worker.setFirstName(json.getString("first_name"));
                     worker.setLastName(json.getString("last_name"));
                     return worker;
+                }
+            } else {
+                throw new IOException("Unexpected status: " + status);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Error calling worker API", e);
+        }
+    }
+
+    private Long callCreateApi(String name, String job) {
+        try {
+            URL url = new URL(API_URL);
+            HttpURLConnection con = (HttpURLConnection) url.openConnection();
+            con.setRequestMethod("POST");
+            con.setRequestProperty("x-api-key", API_KEY);
+            con.setRequestProperty("Content-Type", "application/json");
+            con.setDoOutput(true);
+
+            JSONObject payload = new JSONObject()
+                    .put("name", name)
+                    .put("job", job);
+            byte[] out = payload.toString().getBytes();
+            try (OutputStream os = con.getOutputStream()) {
+                os.write(out);
+            }
+
+            int status = con.getResponseCode();
+            if (status >= 200 && status < 300) {
+                try (BufferedReader in = new BufferedReader(new InputStreamReader(con.getInputStream()))) {
+                    String body = in.lines().collect(Collectors.joining());
+                    JSONObject json = new JSONObject(body);
+                    return Long.parseLong(json.getString("id"));
                 }
             } else {
                 throw new IOException("Unexpected status: " + status);

--- a/infrastructure/src/main/java/com/example/ordenes/infrastructure/server/WorkerHttpServer.java
+++ b/infrastructure/src/main/java/com/example/ordenes/infrastructure/server/WorkerHttpServer.java
@@ -28,9 +28,23 @@ public class WorkerHttpServer {
      */
     public void start(int port) throws IOException {
         server = HttpServer.create(new InetSocketAddress(port), 0);
-        server.createContext("/workers", this::handleGetWorker);
+        server.createContext("/workers", this::handleWorkers);
         server.setExecutor(null);
         server.start();
+    }
+
+    private void handleWorkers(HttpExchange exchange) throws IOException {
+        switch (exchange.getRequestMethod()) {
+            case "GET":
+                handleGetWorker(exchange);
+                break;
+            case "POST":
+                handleCreateWorker(exchange);
+                break;
+            default:
+                exchange.sendResponseHeaders(405, -1);
+                exchange.close();
+        }
     }
 
     private void handleGetWorker(HttpExchange exchange) throws IOException {
@@ -68,5 +82,35 @@ public class WorkerHttpServer {
         } finally {
             exchange.close();
         }
+    }
+
+    private void handleCreateWorker(HttpExchange exchange) throws IOException {
+        if (!"POST".equals(exchange.getRequestMethod())) {
+            exchange.sendResponseHeaders(405, -1);
+            return;
+        }
+
+        JSONObject body = new JSONObject(new String(exchange.getRequestBody().readAllBytes()));
+        String name = body.optString("name", null);
+        String job = body.optString("job", null);
+        if (name == null || job == null) {
+            exchange.sendResponseHeaders(400, -1);
+            exchange.close();
+            return;
+        }
+
+        Optional<Long> id = manageWorkerUseCase.create(name, job);
+        if (id.isPresent()) {
+            JSONObject responseJson = new JSONObject().put("id", id.get());
+            byte[] response = responseJson.toString().getBytes();
+            exchange.getResponseHeaders().set("Content-Type", "application/json");
+            exchange.sendResponseHeaders(201, response.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(response);
+            }
+        } else {
+            exchange.sendResponseHeaders(502, -1);
+        }
+        exchange.close();
     }
 }


### PR DESCRIPTION
## Summary
- expose `POST /workers` endpoint
- implement `create` method in use case and repository
- connect to reqres.in for worker creation
- document new endpoint in README

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_6850581bb694832ab7671c76b0c620ce