### PR TITLE
Implement full worker creation response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,29 @@
+# IntelliJ IDEA
+.idea/
+*.iml
+
+# Gradle
+.gradle/
+**/build/
+
+# Excepciones para gradle wrapper
+!gradle/wrapper/gradle-wrapper.jar
+
+# SonarLint
+.idea/sonarlint/
+.idea/modules/
+.idea/libraries/
+
+# Java class files
+*.class
+
+# Logs
+*.log
+
+# Temporary files
+*.tmp
+*.swp
+
+# OS files
+.DS_Store
+Thumbs.db

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -2,7 +2,18 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
-      <module fileurl="file://$PROJECT_DIR$/.idea/ordenes-producci-n.iml" filepath="$PROJECT_DIR$/.idea/ordenes-producci-n.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/ordenes-produccion.iml" filepath="$PROJECT_DIR$/.idea/modules/ordenes-produccion.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/application/ordenes-produccion.application.iml" filepath="$PROJECT_DIR$/.idea/modules/application/ordenes-produccion.application.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/application/ordenes-produccion.application.main.iml" filepath="$PROJECT_DIR$/.idea/modules/application/ordenes-produccion.application.main.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/application/ordenes-produccion.application.test.iml" filepath="$PROJECT_DIR$/.idea/modules/application/ordenes-produccion.application.test.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/domain/ordenes-produccion.domain.iml" filepath="$PROJECT_DIR$/.idea/modules/domain/ordenes-produccion.domain.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/domain/ordenes-produccion.domain.main.iml" filepath="$PROJECT_DIR$/.idea/modules/domain/ordenes-produccion.domain.main.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/domain/ordenes-produccion.domain.test.iml" filepath="$PROJECT_DIR$/.idea/modules/domain/ordenes-produccion.domain.test.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/infrastructure/ordenes-produccion.infrastructure.iml" filepath="$PROJECT_DIR$/.idea/modules/infrastructure/ordenes-produccion.infrastructure.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/infrastructure/ordenes-produccion.infrastructure.main.iml" filepath="$PROJECT_DIR$/.idea/modules/infrastructure/ordenes-produccion.infrastructure.main.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/infrastructure/ordenes-produccion.infrastructure.test.iml" filepath="$PROJECT_DIR$/.idea/modules/infrastructure/ordenes-produccion.infrastructure.test.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/ordenes-produccion.main.iml" filepath="$PROJECT_DIR$/.idea/modules/ordenes-produccion.main.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/ordenes-produccion.test.iml" filepath="$PROJECT_DIR$/.idea/modules/ordenes-produccion.test.iml" />
     </modules>
   </component>
 </project>

--- a/.idea/sonarlint/issuestore/index.pb
+++ b/.idea/sonarlint/issuestore/index.pb
@@ -27,3 +27,8 @@ H
 application/build.gradle,a\a\aa9cf0dce48be9892530b6983bf9282cc49f2a75
 K
 infrastructure/build.gradle,d\0\d08ad7275ca05d13cb570f6f624eee8075619a60
+Œ
+\infrastructure/src/main/java/com/example/ordenes/infrastructure/server/WorkerHttpServer.java,d\f\df874f9e75557a23b1f38a3a3ac106425dd8bd39
+:
+
+.gitignore,a\5\a5cc2925ca8258af241be7e5b0381edf30266302

--- a/.idea/sonarlint/securityhotspotstore/index.pb
+++ b/.idea/sonarlint/securityhotspotstore/index.pb
@@ -27,3 +27,8 @@ H
 application/build.gradle,a\a\aa9cf0dce48be9892530b6983bf9282cc49f2a75
 K
 infrastructure/build.gradle,d\0\d08ad7275ca05d13cb570f6f624eee8075619a60
+Œ
+\infrastructure/src/main/java/com/example/ordenes/infrastructure/server/WorkerHttpServer.java,d\f\df874f9e75557a23b1f38a3a3ac106425dd8bd39
+:
+
+.gitignore,a\5\a5cc2925ca8258af241be7e5b0381edf30266302

--- a/README.md
+++ b/README.md
@@ -28,7 +28,27 @@ gradle :infrastructure:run
 ```
 
 Luego podrá acceder con Postman a `http://localhost:8080/workers/{id}` para
-obtener la información de un trabajador.
+obtener la información de un trabajador o realizar un `POST` a
+`http://localhost:8080/workers` para dar de alta uno nuevo. El cuerpo de la
+petición debe incluir `name` y `job`:
+
+```json
+{
+  "name": "morpheus",
+  "job": "leader"
+}
+```
+
+La respuesta de la API incluirá el identificador asignado y la fecha de creación:
+
+```json
+{
+  "name": "morpheus",
+  "job": "leader",
+  "id": "358",
+  "createdAt": "2025-06-17T02:55:31.927Z"
+}
+```
 
 El registro de trabajadores se obtiene de la API pública de ReqRes.
 Cada petición envía la cabecera `x-api-key: reqres-free-v1` y está

--- a/application/src/main/java/com/example/ordenes/application/usecase/ManageWorkerService.java
+++ b/application/src/main/java/com/example/ordenes/application/usecase/ManageWorkerService.java
@@ -1,6 +1,7 @@
 package com.example.ordenes.application.usecase;
 
 import com.example.ordenes.domain.model.Worker;
+import com.example.ordenes.domain.model.CreatedWorker;
 import com.example.ordenes.domain.repository.WorkerRepository;
 
 import java.util.Optional;
@@ -19,5 +20,10 @@ public class ManageWorkerService implements ManageWorkerUseCase {
     @Override
     public Optional<Worker> get(Long id) {
         return repository.findById(id);
+    }
+
+    @Override
+    public Optional<CreatedWorker> create(String name, String job) {
+        return repository.create(name, job);
     }
 }

--- a/application/src/main/java/com/example/ordenes/application/usecase/ManageWorkerService.java
+++ b/application/src/main/java/com/example/ordenes/application/usecase/ManageWorkerService.java
@@ -4,6 +4,7 @@ import com.example.ordenes.domain.model.Worker;
 import com.example.ordenes.domain.model.CreatedWorker;
 import com.example.ordenes.domain.repository.WorkerRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -25,5 +26,10 @@ public class ManageWorkerService implements ManageWorkerUseCase {
     @Override
     public Optional<CreatedWorker> create(String name, String job) {
         return repository.create(name, job);
+    }
+
+    @Override
+    public List<Worker> list(int page) {
+        return repository.list(page);
     }
 }

--- a/application/src/main/java/com/example/ordenes/application/usecase/ManageWorkerUseCase.java
+++ b/application/src/main/java/com/example/ordenes/application/usecase/ManageWorkerUseCase.java
@@ -1,6 +1,7 @@
 package com.example.ordenes.application.usecase;
 
 import com.example.ordenes.domain.model.Worker;
+import com.example.ordenes.domain.model.CreatedWorker;
 
 import java.util.Optional;
 
@@ -10,4 +11,6 @@ import java.util.Optional;
 public interface ManageWorkerUseCase {
 
     Optional<Worker> get(Long id);
+
+    Optional<CreatedWorker> create(String name, String job);
 }

--- a/application/src/main/java/com/example/ordenes/application/usecase/ManageWorkerUseCase.java
+++ b/application/src/main/java/com/example/ordenes/application/usecase/ManageWorkerUseCase.java
@@ -3,6 +3,7 @@ package com.example.ordenes.application.usecase;
 import com.example.ordenes.domain.model.Worker;
 import com.example.ordenes.domain.model.CreatedWorker;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -13,4 +14,6 @@ public interface ManageWorkerUseCase {
     Optional<Worker> get(Long id);
 
     Optional<CreatedWorker> create(String name, String job);
+
+    List<Worker> list(int page);
 }

--- a/domain/src/main/java/com/example/ordenes/domain/model/CreatedWorker.java
+++ b/domain/src/main/java/com/example/ordenes/domain/model/CreatedWorker.java
@@ -1,0 +1,44 @@
+package com.example.ordenes.domain.model;
+
+/**
+ * Representa la respuesta al crear un trabajador.
+ */
+public class CreatedWorker {
+
+    private Long id;
+    private String name;
+    private String job;
+    private String createdAt;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getJob() {
+        return job;
+    }
+
+    public void setJob(String job) {
+        this.job = job;
+    }
+
+    public String getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(String createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/domain/src/main/java/com/example/ordenes/domain/repository/WorkerRepository.java
+++ b/domain/src/main/java/com/example/ordenes/domain/repository/WorkerRepository.java
@@ -3,6 +3,7 @@ package com.example.ordenes.domain.repository;
 import com.example.ordenes.domain.model.Worker;
 import com.example.ordenes.domain.model.CreatedWorker;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -16,4 +17,9 @@ public interface WorkerRepository {
      * Crea un nuevo trabajador.
      */
     Optional<CreatedWorker> create(String name, String job);
+
+    /**
+     * Obtiene la lista de trabajadores de la página indicada.
+     */
+    List<Worker> list(int page);
 }

--- a/domain/src/main/java/com/example/ordenes/domain/repository/WorkerRepository.java
+++ b/domain/src/main/java/com/example/ordenes/domain/repository/WorkerRepository.java
@@ -1,6 +1,7 @@
 package com.example.ordenes.domain.repository;
 
 import com.example.ordenes.domain.model.Worker;
+import com.example.ordenes.domain.model.CreatedWorker;
 
 import java.util.Optional;
 
@@ -10,4 +11,9 @@ import java.util.Optional;
 public interface WorkerRepository {
 
     Optional<Worker> findById(Long id);
+
+    /**
+     * Crea un nuevo trabajador.
+     */
+    Optional<CreatedWorker> create(String name, String job);
 }

--- a/gitignore.git
+++ b/gitignore.git
@@ -1,2 +1,0 @@
-.gradle/
-build/

--- a/infrastructure/src/main/java/com/example/ordenes/infrastructure/api/WorkerApiRepository.java
+++ b/infrastructure/src/main/java/com/example/ordenes/infrastructure/api/WorkerApiRepository.java
@@ -11,9 +11,12 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import org.json.JSONArray;
 import org.json.JSONObject;
 
 /**
@@ -46,6 +49,15 @@ public class WorkerApiRepository implements WorkerRepository {
             return circuitBreaker.execute(() -> Optional.ofNullable(callCreateApi(name, job)));
         } catch (RuntimeException e) {
             return Optional.empty();
+        }
+    }
+
+    @Override
+    public List<Worker> list(int page) {
+        try {
+            return circuitBreaker.execute(() -> callListApi(page));
+        } catch (RuntimeException e) {
+            return new ArrayList<>();
         }
     }
 
@@ -104,6 +116,39 @@ public class WorkerApiRepository implements WorkerRepository {
                     cw.setJob(json.optString("job"));
                     cw.setCreatedAt(json.optString("createdAt"));
                     return cw;
+                }
+            } else {
+                throw new IOException("Unexpected status: " + status);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Error calling worker API", e);
+        }
+    }
+
+    private List<Worker> callListApi(int page) {
+        try {
+            URL url = new URL(API_URL + "?page=" + page);
+            HttpURLConnection con = (HttpURLConnection) url.openConnection();
+            con.setRequestMethod("GET");
+            con.setRequestProperty("x-api-key", API_KEY);
+
+            int status = con.getResponseCode();
+            if (status >= 200 && status < 300) {
+                try (BufferedReader in = new BufferedReader(new InputStreamReader(con.getInputStream()))) {
+                    String body = in.lines().collect(Collectors.joining());
+                    JSONObject json = new JSONObject(body);
+                    JSONArray arr = json.getJSONArray("data");
+                    List<Worker> workers = new ArrayList<>();
+                    for (int i = 0; i < arr.length(); i++) {
+                        JSONObject obj = arr.getJSONObject(i);
+                        Worker worker = new Worker();
+                        worker.setId(obj.getLong("id"));
+                        worker.setEmail(obj.getString("email"));
+                        worker.setFirstName(obj.getString("first_name"));
+                        worker.setLastName(obj.getString("last_name"));
+                        workers.add(worker);
+                    }
+                    return workers;
                 }
             } else {
                 throw new IOException("Unexpected status: " + status);

--- a/infrastructure/src/main/java/com/example/ordenes/infrastructure/api/WorkerApiRepository.java
+++ b/infrastructure/src/main/java/com/example/ordenes/infrastructure/api/WorkerApiRepository.java
@@ -1,12 +1,14 @@
 package com.example.ordenes.infrastructure.api;
 
 import com.example.ordenes.domain.model.Worker;
+import com.example.ordenes.domain.model.CreatedWorker;
 import com.example.ordenes.domain.repository.WorkerRepository;
 import com.example.ordenes.infrastructure.circuit.CircuitBreaker;
 
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.Optional;
@@ -38,6 +40,15 @@ public class WorkerApiRepository implements WorkerRepository {
         }
     }
 
+    @Override
+    public Optional<CreatedWorker> create(String name, String job) {
+        try {
+            return circuitBreaker.execute(() -> Optional.ofNullable(callCreateApi(name, job)));
+        } catch (RuntimeException e) {
+            return Optional.empty();
+        }
+    }
+
     private Worker callApi(Long id) {
         try {
             URL url = new URL(API_URL + id);
@@ -56,6 +67,43 @@ public class WorkerApiRepository implements WorkerRepository {
                     worker.setFirstName(json.getString("first_name"));
                     worker.setLastName(json.getString("last_name"));
                     return worker;
+                }
+            } else {
+                throw new IOException("Unexpected status: " + status);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Error calling worker API", e);
+        }
+    }
+
+    private CreatedWorker callCreateApi(String name, String job) {
+        try {
+            URL url = new URL(API_URL);
+            HttpURLConnection con = (HttpURLConnection) url.openConnection();
+            con.setRequestMethod("POST");
+            con.setRequestProperty("x-api-key", API_KEY);
+            con.setRequestProperty("Content-Type", "application/json");
+            con.setDoOutput(true);
+
+            JSONObject payload = new JSONObject()
+                    .put("name", name)
+                    .put("job", job);
+            byte[] out = payload.toString().getBytes();
+            try (OutputStream os = con.getOutputStream()) {
+                os.write(out);
+            }
+
+            int status = con.getResponseCode();
+            if (status >= 200 && status < 300) {
+                try (BufferedReader in = new BufferedReader(new InputStreamReader(con.getInputStream()))) {
+                    String body = in.lines().collect(Collectors.joining());
+                    JSONObject json = new JSONObject(body);
+                    CreatedWorker cw = new CreatedWorker();
+                    cw.setId(Long.parseLong(json.getString("id")));
+                    cw.setName(json.optString("name"));
+                    cw.setJob(json.optString("job"));
+                    cw.setCreatedAt(json.optString("createdAt"));
+                    return cw;
                 }
             } else {
                 throw new IOException("Unexpected status: " + status);

--- a/infrastructure/src/main/java/com/example/ordenes/infrastructure/server/WorkerHttpServer.java
+++ b/infrastructure/src/main/java/com/example/ordenes/infrastructure/server/WorkerHttpServer.java
@@ -5,6 +5,7 @@ import com.example.ordenes.domain.model.Worker;
 import com.example.ordenes.domain.model.CreatedWorker;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpServer;
+import org.json.JSONArray;
 import org.json.JSONObject;
 
 import java.io.BufferedReader;
@@ -15,6 +16,7 @@ import java.util.stream.Collectors;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -42,7 +44,12 @@ public class WorkerHttpServer {
     private void handleWorkers(HttpExchange exchange) throws IOException {
         switch (exchange.getRequestMethod()) {
             case "GET":
-                handleGetWorker(exchange);
+                String path = exchange.getRequestURI().getPath();
+                if ("/workers".equals(path) || "/workers/".equals(path)) {
+                    handleListWorkers(exchange);
+                } else {
+                    handleGetWorker(exchange);
+                }
                 break;
             case "POST":
                 handleCreateWorker(exchange);
@@ -126,6 +133,41 @@ public class WorkerHttpServer {
             }
         } else {
             exchange.sendResponseHeaders(502, -1);
+        }
+        exchange.close();
+    }
+
+    private void handleListWorkers(HttpExchange exchange) throws IOException {
+        int page = 1;
+        String query = exchange.getRequestURI().getQuery();
+        if (query != null) {
+            for (String part : query.split("&")) {
+                String[] kv = part.split("=");
+                if (kv.length == 2 && "page".equals(kv[0])) {
+                    try {
+                        page = Integer.parseInt(kv[1]);
+                    } catch (NumberFormatException ignore) {
+                        // default
+                    }
+                }
+            }
+        }
+
+        List<Worker> workers = manageWorkerUseCase.list(page);
+        JSONArray array = new JSONArray();
+        for (Worker w : workers) {
+            array.put(new JSONObject()
+                    .put("id", w.getId())
+                    .put("email", w.getEmail())
+                    .put("firstName", w.getFirstName())
+                    .put("lastName", w.getLastName()));
+        }
+        JSONObject responseJson = new JSONObject().put("data", array);
+        byte[] response = responseJson.toString().getBytes();
+        exchange.getResponseHeaders().set("Content-Type", "application/json");
+        exchange.sendResponseHeaders(200, response.length);
+        try (OutputStream os = exchange.getResponseBody()) {
+            os.write(response);
         }
         exchange.close();
     }

--- a/infrastructure/src/main/java/com/example/ordenes/infrastructure/server/WorkerHttpServer.java
+++ b/infrastructure/src/main/java/com/example/ordenes/infrastructure/server/WorkerHttpServer.java
@@ -2,9 +2,15 @@ package com.example.ordenes.infrastructure.server;
 
 import com.example.ordenes.application.usecase.ManageWorkerUseCase;
 import com.example.ordenes.domain.model.Worker;
+import com.example.ordenes.domain.model.CreatedWorker;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpServer;
 import org.json.JSONObject;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Collectors;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -28,9 +34,23 @@ public class WorkerHttpServer {
      */
     public void start(int port) throws IOException {
         server = HttpServer.create(new InetSocketAddress(port), 0);
-        server.createContext("/workers", this::handleGetWorker);
+        server.createContext("/workers", this::handleWorkers);
         server.setExecutor(null);
         server.start();
+    }
+
+    private void handleWorkers(HttpExchange exchange) throws IOException {
+        switch (exchange.getRequestMethod()) {
+            case "GET":
+                handleGetWorker(exchange);
+                break;
+            case "POST":
+                handleCreateWorker(exchange);
+                break;
+            default:
+                exchange.sendResponseHeaders(405, -1);
+                exchange.close();
+        }
     }
 
     private void handleGetWorker(HttpExchange exchange) throws IOException {
@@ -68,5 +88,45 @@ public class WorkerHttpServer {
         } finally {
             exchange.close();
         }
+    }
+
+    private void handleCreateWorker(HttpExchange exchange) throws IOException {
+        if (!"POST".equals(exchange.getRequestMethod())) {
+            exchange.sendResponseHeaders(405, -1);
+            return;
+        }
+
+        String requestBody;
+        try (BufferedReader reader = new BufferedReader(
+                new InputStreamReader(exchange.getRequestBody(), StandardCharsets.UTF_8))) {
+            requestBody = reader.lines().collect(Collectors.joining());
+        }
+        JSONObject body = new JSONObject(requestBody);
+        String name = body.optString("name", null);
+        String job = body.optString("job", null);
+        if (name == null || job == null) {
+            exchange.sendResponseHeaders(400, -1);
+            exchange.close();
+            return;
+        }
+
+        Optional<CreatedWorker> created = manageWorkerUseCase.create(name, job);
+        if (created.isPresent()) {
+            CreatedWorker cw = created.get();
+            JSONObject responseJson = new JSONObject()
+                    .put("name", cw.getName())
+                    .put("job", cw.getJob())
+                    .put("id", cw.getId())
+                    .put("createdAt", cw.getCreatedAt());
+            byte[] response = responseJson.toString().getBytes();
+            exchange.getResponseHeaders().set("Content-Type", "application/json");
+            exchange.sendResponseHeaders(201, response.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(response);
+            }
+        } else {
+            exchange.sendResponseHeaders(502, -1);
+        }
+        exchange.close();
     }
 }


### PR DESCRIPTION
## Summary
- capture complete response from reqres `POST /api/users`
- propagate `CreatedWorker` object through repository and use case
- return name, job, id, and createdAt from HTTP server
- document example request and response for `POST /workers`

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6850581bb694832ab7671c76b0c620ce