### PR TITLE
Add worker update endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,26 @@ La respuesta de la API incluirá el identificador asignado y la fecha de creaci�
 ```
 `http://localhost:8080/workers` para dar de alta uno nuevo.
 
+Si desea modificar un trabajador existente puede realizar un `PUT` a
+`http://localhost:8080/workers/{id}` con los nuevos datos:
+
+```json
+{
+  "name": "morpheus",
+  "job": "zion resident"
+}
+```
+
+La respuesta será similar a:
+
+```json
+{
+  "name": "morpheus",
+  "job": "zion resident",
+  "updatedAt": "2025-06-18T02:50:58.315Z"
+}
+```
+
 El registro de trabajadores se obtiene de la API pública de ReqRes.
 Cada petición envía la cabecera `x-api-key: reqres-free-v1` y está
 protegida por un Circuit Breaker básico en el módulo `infrastructure`.

--- a/application/src/main/java/com/example/ordenes/application/usecase/ManageWorkerService.java
+++ b/application/src/main/java/com/example/ordenes/application/usecase/ManageWorkerService.java
@@ -3,6 +3,7 @@ package com.example.ordenes.application.usecase;
 import com.example.ordenes.domain.model.Worker;
 import com.example.ordenes.domain.model.CreatedWorker;
 import com.example.ordenes.domain.repository.WorkerRepository;
+import com.example.ordenes.domain.model.UpdatedWorker;
 
 import java.util.List;
 import java.util.Optional;
@@ -26,6 +27,11 @@ public class ManageWorkerService implements ManageWorkerUseCase {
     @Override
     public Optional<CreatedWorker> create(String name, String job) {
         return repository.create(name, job);
+    }
+
+    @Override
+    public Optional<UpdatedWorker> update(Long id, String name, String job) {
+        return repository.update(id, name, job);
     }
 
     @Override

--- a/application/src/main/java/com/example/ordenes/application/usecase/ManageWorkerUseCase.java
+++ b/application/src/main/java/com/example/ordenes/application/usecase/ManageWorkerUseCase.java
@@ -2,6 +2,7 @@ package com.example.ordenes.application.usecase;
 
 import com.example.ordenes.domain.model.Worker;
 import com.example.ordenes.domain.model.CreatedWorker;
+import com.example.ordenes.domain.model.UpdatedWorker;
 
 import java.util.List;
 import java.util.Optional;
@@ -14,6 +15,8 @@ public interface ManageWorkerUseCase {
     Optional<Worker> get(Long id);
 
     Optional<CreatedWorker> create(String name, String job);
+
+    Optional<UpdatedWorker> update(Long id, String name, String job);
 
     List<Worker> list(int page);
 }

--- a/domain/src/main/java/com/example/ordenes/domain/model/UpdatedWorker.java
+++ b/domain/src/main/java/com/example/ordenes/domain/model/UpdatedWorker.java
@@ -1,0 +1,35 @@
+package com.example.ordenes.domain.model;
+
+/**
+ * Representa la respuesta al actualizar un trabajador.
+ */
+public class UpdatedWorker {
+
+    private String name;
+    private String job;
+    private String updatedAt;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getJob() {
+        return job;
+    }
+
+    public void setJob(String job) {
+        this.job = job;
+    }
+
+    public String getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(String updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/domain/src/main/java/com/example/ordenes/domain/repository/WorkerRepository.java
+++ b/domain/src/main/java/com/example/ordenes/domain/repository/WorkerRepository.java
@@ -2,6 +2,7 @@ package com.example.ordenes.domain.repository;
 
 import com.example.ordenes.domain.model.Worker;
 import com.example.ordenes.domain.model.CreatedWorker;
+import com.example.ordenes.domain.model.UpdatedWorker;
 
 import java.util.List;
 import java.util.Optional;
@@ -17,6 +18,11 @@ public interface WorkerRepository {
      * Crea un nuevo trabajador.
      */
     Optional<CreatedWorker> create(String name, String job);
+
+    /**
+     * Actualiza un trabajador existente.
+     */
+    Optional<UpdatedWorker> update(Long id, String name, String job);
 
     /**
      * Obtiene la lista de trabajadores de la página indicada.

--- a/infrastructure/src/main/java/com/example/ordenes/infrastructure/api/WorkerApiRepository.java
+++ b/infrastructure/src/main/java/com/example/ordenes/infrastructure/api/WorkerApiRepository.java
@@ -2,6 +2,7 @@ package com.example.ordenes.infrastructure.api;
 
 import com.example.ordenes.domain.model.Worker;
 import com.example.ordenes.domain.model.CreatedWorker;
+import com.example.ordenes.domain.model.UpdatedWorker;
 import com.example.ordenes.domain.repository.WorkerRepository;
 import com.example.ordenes.infrastructure.circuit.CircuitBreaker;
 
@@ -47,6 +48,15 @@ public class WorkerApiRepository implements WorkerRepository {
     public Optional<CreatedWorker> create(String name, String job) {
         try {
             return circuitBreaker.execute(() -> Optional.ofNullable(callCreateApi(name, job)));
+        } catch (RuntimeException e) {
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public Optional<UpdatedWorker> update(Long id, String name, String job) {
+        try {
+            return circuitBreaker.execute(() -> Optional.ofNullable(callUpdateApi(id, name, job)));
         } catch (RuntimeException e) {
             return Optional.empty();
         }
@@ -116,6 +126,42 @@ public class WorkerApiRepository implements WorkerRepository {
                     cw.setJob(json.optString("job"));
                     cw.setCreatedAt(json.optString("createdAt"));
                     return cw;
+                }
+            } else {
+                throw new IOException("Unexpected status: " + status);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Error calling worker API", e);
+        }
+    }
+
+    private UpdatedWorker callUpdateApi(Long id, String name, String job) {
+        try {
+            URL url = new URL(API_URL + id);
+            HttpURLConnection con = (HttpURLConnection) url.openConnection();
+            con.setRequestMethod("PUT");
+            con.setRequestProperty("x-api-key", API_KEY);
+            con.setRequestProperty("Content-Type", "application/json");
+            con.setDoOutput(true);
+
+            JSONObject payload = new JSONObject()
+                    .put("name", name)
+                    .put("job", job);
+            byte[] out = payload.toString().getBytes();
+            try (OutputStream os = con.getOutputStream()) {
+                os.write(out);
+            }
+
+            int status = con.getResponseCode();
+            if (status >= 200 && status < 300) {
+                try (BufferedReader in = new BufferedReader(new InputStreamReader(con.getInputStream()))) {
+                    String body = in.lines().collect(Collectors.joining());
+                    JSONObject json = new JSONObject(body);
+                    UpdatedWorker uw = new UpdatedWorker();
+                    uw.setName(json.optString("name"));
+                    uw.setJob(json.optString("job"));
+                    uw.setUpdatedAt(json.optString("updatedAt"));
+                    return uw;
                 }
             } else {
                 throw new IOException("Unexpected status: " + status);

--- a/infrastructure/src/main/java/com/example/ordenes/infrastructure/server/WorkerHttpServer.java
+++ b/infrastructure/src/main/java/com/example/ordenes/infrastructure/server/WorkerHttpServer.java
@@ -3,6 +3,7 @@ package com.example.ordenes.infrastructure.server;
 import com.example.ordenes.application.usecase.ManageWorkerUseCase;
 import com.example.ordenes.domain.model.Worker;
 import com.example.ordenes.domain.model.CreatedWorker;
+import com.example.ordenes.domain.model.UpdatedWorker;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpServer;
 import org.json.JSONArray;
@@ -53,6 +54,9 @@ public class WorkerHttpServer {
                 break;
             case "POST":
                 handleCreateWorker(exchange);
+                break;
+            case "PUT":
+                handleUpdateWorker(exchange);
                 break;
             default:
                 exchange.sendResponseHeaders(405, -1);
@@ -128,6 +132,62 @@ public class WorkerHttpServer {
             byte[] response = responseJson.toString().getBytes();
             exchange.getResponseHeaders().set("Content-Type", "application/json");
             exchange.sendResponseHeaders(201, response.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(response);
+            }
+        } else {
+            exchange.sendResponseHeaders(502, -1);
+        }
+        exchange.close();
+    }
+
+    private void handleUpdateWorker(HttpExchange exchange) throws IOException {
+        if (!"PUT".equals(exchange.getRequestMethod())) {
+            exchange.sendResponseHeaders(405, -1);
+            return;
+        }
+
+        String path = exchange.getRequestURI().getPath();
+        String[] parts = path.split("/");
+        if (parts.length != 3) {
+            exchange.sendResponseHeaders(400, -1);
+            exchange.close();
+            return;
+        }
+
+        long id;
+        try {
+            id = Long.parseLong(parts[2]);
+        } catch (NumberFormatException e) {
+            exchange.sendResponseHeaders(400, -1);
+            exchange.close();
+            return;
+        }
+
+        String requestBody;
+        try (BufferedReader reader = new BufferedReader(
+                new InputStreamReader(exchange.getRequestBody(), StandardCharsets.UTF_8))) {
+            requestBody = reader.lines().collect(Collectors.joining());
+        }
+        JSONObject body = new JSONObject(requestBody);
+        String name = body.optString("name", null);
+        String job = body.optString("job", null);
+        if (name == null || job == null) {
+            exchange.sendResponseHeaders(400, -1);
+            exchange.close();
+            return;
+        }
+
+        Optional<UpdatedWorker> updated = manageWorkerUseCase.update(id, name, job);
+        if (updated.isPresent()) {
+            UpdatedWorker uw = updated.get();
+            JSONObject responseJson = new JSONObject()
+                    .put("name", uw.getName())
+                    .put("job", uw.getJob())
+                    .put("updatedAt", uw.getUpdatedAt());
+            byte[] response = responseJson.toString().getBytes();
+            exchange.getResponseHeaders().set("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, response.length);
             try (OutputStream os = exchange.getResponseBody()) {
                 os.write(response);
             }


### PR DESCRIPTION
## Summary
- support updating workers in the domain/model
- expose update operation in repository and use cases
- implement update call against ReqRes API
- handle PUT /workers/{id} in HTTP server
- document new endpoint in README

## Testing
- `gradle build`

------
https://chatgpt.com/codex/tasks/task_e_68522a07d608832aaed7969e72595a9e