### PR TITLE
Add LocalStack setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,37 @@ La respuesta será similar a:
 El registro de trabajadores se obtiene de la API pública de ReqRes.
 Cada petición envía la cabecera `x-api-key: reqres-free-v1` y está
 protegida por un Circuit Breaker básico en el módulo `infrastructure`.
+
+## DynamoDB local con LocalStack
+
+Para probar el proyecto con una base de datos DynamoDB local puede utilizar [LocalStack](https://docs.localstack.cloud/). Se necesita tener Docker y Python instalados.
+
+1. Instale LocalStack:
+
+```bash
+pip install localstack
+```
+
+2. Inicie los servicios (en segundo plano) desde este directorio:
+
+```bash
+docker-compose up -d
+```
+
+Esto levantará LocalStack escuchando en `http://localhost:4566` únicamente con el servicio de DynamoDB habilitado. Puede verificar que está funcionando ejecutando:
+
+```bash
+aws --endpoint-url=http://localhost:4566 dynamodb list-tables
+```
+
+3. Si desea crear una tabla de ejemplo:
+
+```bash
+aws --endpoint-url=http://localhost:4566 dynamodb create-table \
+  --table-name ProductionOrders \
+  --attribute-definitions AttributeName=id,AttributeType=N \
+  --key-schema AttributeName=id,KeyType=HASH \
+  --billing-mode PAY_PER_REQUEST
+```
+
+Con esto dispondrá de un entorno local de DynamoDB para sus pruebas.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3.8'
+services:
+  localstack:
+    image: localstack/localstack:latest
+    ports:
+      - "4566:4566"
+    environment:
+      - SERVICES=dynamodb
+      - DEBUG=1
+    volumes:
+      - "./.localstack:/var/lib/localstack"
+      - "/var/run/docker.sock:/var/run/docker.sock"


### PR DESCRIPTION
## Summary
- provide LocalStack-based DynamoDB instructions in README
- add docker-compose file for LocalStack DynamoDB service

## Testing
- `./gradlew test` *(fails: Permission denied; then runs successfully after permission fix)*
- `localstack start -d` *(fails: Docker could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_685238188d5c832a929f73bd16a4ef76